### PR TITLE
Rev assembly info

### DIFF
--- a/Build/AssemblySharedInfo.cs
+++ b/Build/AssemblySharedInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // NOTE: Assembly name is set in respective project files.
-[assembly: AssemblyVersion("0.23.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.23.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/CreatePackages.bat
+++ b/CreatePackages.bat
@@ -1,0 +1,3 @@
+@echo off
+.nuget\NuGet.exe install .nuget\packages.config -OutputDirectory packages
+powershell.exe -NoProfile -ExecutionPolicy unrestricted -Command "& {Import-Module '.\packages\psake.*\tools\psake.psm1'; invoke-psake .\psake-project.ps1 -Task Pack %*; if ($LastExitCode -and $LastExitCode -ne 0) {write-host "ERROR CODE: $LastExitCode" -fore RED; exit $lastexitcode} }"

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Install-Package SystemWrapper.Wrappers
 Source code is licensed under [Microsoft Public License (MS-PL)](LICENSE.txt).
 
 Source code is forked from [https://systemwrapper.codeplex.com/](https://systemwrapper.codeplex.com/).
+
+## TechSmith Updates
+
+We've added a new batch file, `CreatePackages.bat`, which will automatically build and create nuget packages for SystemWrapper and SystemInterface. After running this batch file, the packages will be in the `publish` directory.


### PR DESCRIPTION
## Overview

After looking at discussions with the original creators of SystemWrapper, it looks like we only need to update `AssemblyVersion` to generate an updated nuget package. I also added a batch file that runs a psake script (already included in the repo) that will auto-build and auto-pack the nuget packages, we should be able to call this batch file from Team City.