### PR TITLE
Customize nuget package names

### DIFF
--- a/SystemInterface/SystemInterface.nuspec
+++ b/SystemInterface/SystemInterface.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>SystemWrapper.Interfaces</id>
+    <id>system-interfaces-tsc-package</id>
     <version>$Version$</version>
     <authors>Jozef Izso, Yann Brulhart</authors>
     <owners>Jozef Izso</owners>

--- a/SystemWrapper/SystemWrapper.nuspec
+++ b/SystemWrapper/SystemWrapper.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>SystemWrapper.Wrappers</id>
+    <id>system-wrappers-tsc-package</id>
     <version>$Version$</version>
     <authors>Jozef Izso, Yann Brulhart</authors>
     <owners>Jozef Izso</owners>
@@ -14,7 +14,7 @@ Droped support for .NET 4.0</releaseNotes>
     <copyright>Copyright (c) 2014-2016 Jozef Izso</copyright>
     <tags>SystemWrapper mocks unit tests registry filesystem</tags>
     <dependencies>
-      <dependency id="SystemWrapper.Interfaces" version="[$Version$]" />
+      <dependency id="system-interfaces-tsc-package" version="[$Version$]" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
This is so we don't run into any naming conflicts. Our fork is technically identical to the original repo, but has a different version number. Just in case updates are made to the original and the version number changes to match ours, we want to make sure ours has a unique name so there's no confusion.