### PR TITLE
Bug/zip file wrap should pass encoding param

### DIFF
--- a/Build/AssemblySharedInfo.cs
+++ b/Build/AssemblySharedInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // NOTE: Assembly name is set in respective project files.
-[assembly: AssemblyVersion("0.23.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("0.23.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]

--- a/SystemWrapper/IO/Compression/ZipFileWrap.cs
+++ b/SystemWrapper/IO/Compression/ZipFileWrap.cs
@@ -38,7 +38,7 @@ namespace SystemWrapper.IO.Compression
 
         public IZipArchive Open(string archiveFileName, System.IO.Compression.ZipArchiveMode mode, Encoding entryNameEncoding)
         {
-            return new ZipArchiveWrap(ZipFile.Open(archiveFileName, mode));
+            return new ZipArchiveWrap(ZipFile.Open(archiveFileName, mode, entryNameEncoding));
         }
 
         public IZipArchive OpenRead(string archiveFileName)


### PR DESCRIPTION
passing the encoding parameter so that we can construct a ZipArchive wrap with the custom encoding option.